### PR TITLE
Add staging and production orchestration configs

### DIFF
--- a/GIT_ISSUES.md
+++ b/GIT_ISSUES.md
@@ -1,0 +1,9 @@
+# Git Issues
+
+| ID | Statut | Description | Résolution |
+|----|--------|-------------|------------|
+| #1 | Fermé | Créer un fichier `docker-compose/staging.yml` pour l'environnement de staging. | Ajout d'une configuration staging complète (services, monitoring, volumes) et scripts de démarrage/arrêt associés. |
+| #2 | Fermé | Créer un fichier `docker-compose/production.yml` pour l'environnement de production. | Ajout d'une configuration production avec variables obligatoires, monitoring et scripts dédiés. |
+| #3 | Fermé | Fournir des scripts pour gérer les environnements staging et production. | Ajout de `start/stop-staging.sh` et `start/stop-production.sh`. |
+
+> **État actuel :** aucune issue ouverte.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,23 @@ Infrastructure et orchestration pour Project Umbra - Gestion centralisée de tou
 
 ### Environnement de Développement
 ```bash
-# Démarrer tous les services
+# Démarrer tous les services (développement)
 ./scripts/start-dev.sh
 
-# Arrêter tous les services
+# Arrêter tous les services (développement)
 ./scripts/stop-dev.sh
+
+# Démarrer l'environnement de staging
+./scripts/start-staging.sh
+
+# Arrêter l'environnement de staging
+./scripts/stop-staging.sh
+
+# Démarrer l'environnement de production
+./scripts/start-production.sh
+
+# Arrêter l'environnement de production
+./scripts/stop-production.sh
 ```
 
 ### Accès aux Services
@@ -44,6 +56,9 @@ Infrastructure et orchestration pour Project Umbra - Gestion centralisée de tou
 
 ### Variables d'Environnement
 Chaque service utilise ses propres variables d'environnement définies dans le docker-compose.
+
+- **Staging :** les URLs de base de données par défaut utilisent les mêmes identifiants que l'environnement de développement (`dev_password`). Surcharger les variables `*_DATABASE_URL`/`*_REDIS_URL` si nécessaire.
+- **Production :** toutes les variables critiques doivent être fournies via l'environnement (`docker-compose/production.yml` refuse de démarrer si elles manquent). Provisionner la base de données en amont ou adapter le script d'initialisation selon vos besoins.
 
 ### Base de Données
 Les bases de données sont automatiquement créées au démarrage via le script `init-databases.sql`.
@@ -65,14 +80,17 @@ Les bases de données sont automatiquement créées au démarrage via le script 
 
 ### Environnements
 - **Development:** `docker-compose/development.yml`
-- **Staging:** `docker-compose/staging.yml` (à créer)
-- **Production:** `docker-compose/production.yml` (à créer)
+- **Staging:** `docker-compose/staging.yml`
+- **Production:** `docker-compose/production.yml`
+
+Chaque environnement dispose d'un script dédié dans `scripts/` pour faciliter le démarrage et l'arrêt.
 
 ## 🤝 Contribution
 
 1. Modifier la configuration dans le bon environnement
 2. Tester localement
 3. Créer une Pull Request
+4. Mettre à jour `GIT_ISSUES.md` pour refléter l'état des issues locales
 
 ## 📄 Licence
 

--- a/docker-compose/production.yml
+++ b/docker-compose/production.yml
@@ -1,0 +1,158 @@
+version: '3.8'
+
+x-service-defaults: &service-defaults
+  restart: always
+  depends_on:
+    - postgres
+    - redis
+
+services:
+  auth-service:
+    image: ghcr.io/decarvalhoe/umbra-auth-service:latest
+    ports:
+      - "5000:5000"
+    environment:
+      - DATABASE_URL=${AUTH_DATABASE_URL:?AUTH_DATABASE_URL not set}
+      - REDIS_URL=${AUTH_REDIS_URL:?AUTH_REDIS_URL not set}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY not set}
+      - ENVIRONMENT=production
+    <<: *service-defaults
+
+  player-service:
+    image: ghcr.io/decarvalhoe/umbra-player-service:latest
+    ports:
+      - "5001:5001"
+    environment:
+      - DATABASE_URL=${PLAYER_DATABASE_URL:?PLAYER_DATABASE_URL not set}
+      - REDIS_URL=${PLAYER_REDIS_URL:?PLAYER_REDIS_URL not set}
+      - ENVIRONMENT=production
+    <<: *service-defaults
+
+  game-state-service:
+    image: ghcr.io/decarvalhoe/umbra-game-state-service:latest
+    ports:
+      - "5002:5002"
+    environment:
+      - DATABASE_URL=${GAME_DATABASE_URL:?GAME_DATABASE_URL not set}
+      - REDIS_URL=${GAME_REDIS_URL:?GAME_REDIS_URL not set}
+      - ENVIRONMENT=production
+    <<: *service-defaults
+
+  payment-service:
+    image: ghcr.io/decarvalhoe/umbra-payment-service:latest
+    ports:
+      - "5003:5003"
+    environment:
+      - DATABASE_URL=${PAYMENT_DATABASE_URL:?PAYMENT_DATABASE_URL not set}
+      - REDIS_URL=${PAYMENT_REDIS_URL:?PAYMENT_REDIS_URL not set}
+      - ENVIRONMENT=production
+    <<: *service-defaults
+
+  cloud-profile-service:
+    image: ghcr.io/decarvalhoe/umbra-cloud-profile-service:latest
+    ports:
+      - "5004:5004"
+    environment:
+      - DATABASE_URL=${CLOUD_DATABASE_URL:?CLOUD_DATABASE_URL not set}
+      - REDIS_URL=${CLOUD_REDIS_URL:?CLOUD_REDIS_URL not set}
+      - ENVIRONMENT=production
+    <<: *service-defaults
+
+  security-service:
+    image: ghcr.io/decarvalhoe/umbra-security-service:latest
+    ports:
+      - "5006:5006"
+    environment:
+      - DATABASE_URL=${SECURITY_DATABASE_URL:?SECURITY_DATABASE_URL not set}
+      - REDIS_URL=${SECURITY_REDIS_URL:?SECURITY_REDIS_URL not set}
+      - ENVIRONMENT=production
+    <<: *service-defaults
+
+  localization-service:
+    image: ghcr.io/decarvalhoe/umbra-localization-service:latest
+    ports:
+      - "5007:5007"
+    environment:
+      - DATABASE_URL=${LOCALIZATION_DATABASE_URL:?LOCALIZATION_DATABASE_URL not set}
+      - REDIS_URL=${LOCALIZATION_REDIS_URL:?LOCALIZATION_REDIS_URL not set}
+      - ENVIRONMENT=production
+    <<: *service-defaults
+
+  game-client:
+    image: ghcr.io/decarvalhoe/umbra-game-client:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - VITE_API_BASE_URL=${GAME_CLIENT_API_BASE_URL:?GAME_CLIENT_API_BASE_URL not set}
+      - VITE_ENVIRONMENT=production
+    restart: always
+    depends_on:
+      - nginx
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - auth-service
+      - player-service
+      - game-state-service
+      - payment-service
+      - cloud-profile-service
+      - security-service
+      - localization-service
+    restart: always
+
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD not set}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_production_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: always
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_production_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: always
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    restart: always
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:?GF_SECURITY_ADMIN_PASSWORD not set}
+    volumes:
+      - grafana_production_data:/var/lib/grafana
+    restart: always
+
+volumes:
+  postgres_production_data:
+  redis_production_data:
+  grafana_production_data:

--- a/docker-compose/staging.yml
+++ b/docker-compose/staging.yml
@@ -1,0 +1,157 @@
+version: '3.8'
+
+x-service-defaults: &service-defaults
+  restart: unless-stopped
+  depends_on:
+    - postgres
+    - redis
+
+services:
+  auth-service:
+    image: ghcr.io/decarvalhoe/umbra-auth-service:latest
+    ports:
+      - "5000:5000"
+    environment:
+      - DATABASE_URL=${AUTH_DATABASE_URL:-postgresql://umbra_auth:dev_password@postgres:5432/umbra_auth}
+      - REDIS_URL=${AUTH_REDIS_URL:-redis://redis:6379/0}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-staging-secret-key}
+      - ENVIRONMENT=staging
+    <<: *service-defaults
+
+  player-service:
+    image: ghcr.io/decarvalhoe/umbra-player-service:latest
+    ports:
+      - "5001:5001"
+    environment:
+      - DATABASE_URL=${PLAYER_DATABASE_URL:-postgresql://umbra_player:dev_password@postgres:5432/umbra_player}
+      - REDIS_URL=${PLAYER_REDIS_URL:-redis://redis:6379/1}
+      - ENVIRONMENT=staging
+    <<: *service-defaults
+
+  game-state-service:
+    image: ghcr.io/decarvalhoe/umbra-game-state-service:latest
+    ports:
+      - "5002:5002"
+    environment:
+      - DATABASE_URL=${GAME_DATABASE_URL:-postgresql://umbra_game:dev_password@postgres:5432/umbra_game}
+      - REDIS_URL=${GAME_REDIS_URL:-redis://redis:6379/2}
+      - ENVIRONMENT=staging
+    <<: *service-defaults
+
+  payment-service:
+    image: ghcr.io/decarvalhoe/umbra-payment-service:latest
+    ports:
+      - "5003:5003"
+    environment:
+      - DATABASE_URL=${PAYMENT_DATABASE_URL:-postgresql://umbra_payment:dev_password@postgres:5432/umbra_payment}
+      - REDIS_URL=${PAYMENT_REDIS_URL:-redis://redis:6379/3}
+      - ENVIRONMENT=staging
+    <<: *service-defaults
+
+  cloud-profile-service:
+    image: ghcr.io/decarvalhoe/umbra-cloud-profile-service:latest
+    ports:
+      - "5004:5004"
+    environment:
+      - DATABASE_URL=${CLOUD_DATABASE_URL:-postgresql://umbra_cloud:dev_password@postgres:5432/umbra_cloud}
+      - REDIS_URL=${CLOUD_REDIS_URL:-redis://redis:6379/4}
+      - ENVIRONMENT=staging
+    <<: *service-defaults
+
+  security-service:
+    image: ghcr.io/decarvalhoe/umbra-security-service:latest
+    ports:
+      - "5006:5006"
+    environment:
+      - DATABASE_URL=${SECURITY_DATABASE_URL:-postgresql://umbra_security:dev_password@postgres:5432/umbra_security}
+      - REDIS_URL=${SECURITY_REDIS_URL:-redis://redis:6379/5}
+      - ENVIRONMENT=staging
+    <<: *service-defaults
+
+  localization-service:
+    image: ghcr.io/decarvalhoe/umbra-localization-service:latest
+    ports:
+      - "5007:5007"
+    environment:
+      - DATABASE_URL=${LOCALIZATION_DATABASE_URL:-postgresql://umbra_i18n:dev_password@postgres:5432/umbra_i18n}
+      - REDIS_URL=${LOCALIZATION_REDIS_URL:-redis://redis:6379/6}
+      - ENVIRONMENT=staging
+    <<: *service-defaults
+
+  game-client:
+    image: ghcr.io/decarvalhoe/umbra-game-client:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - VITE_API_BASE_URL=${GAME_CLIENT_API_BASE_URL:-http://localhost:8080/api}
+      - VITE_ENVIRONMENT=staging
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - auth-service
+      - player-service
+      - game-state-service
+      - payment-service
+      - cloud-profile-service
+      - security-service
+      - localization-service
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-staging_password}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_staging_data:/var/lib/postgresql/data
+      - ./scripts/init-databases.sql:/docker-entrypoint-initdb.d/init-databases.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_staging_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-staging-admin}
+    volumes:
+      - grafana_staging_data:/var/lib/grafana
+    restart: unless-stopped
+
+volumes:
+  postgres_staging_data:
+  redis_staging_data:
+  grafana_staging_data:

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 echo "🚀 Démarrage de l'environnement de développement Project Umbra"
 docker-compose -f docker-compose/development.yml up -d
 echo "✅ Environnement démarré"

--- a/scripts/start-production.sh
+++ b/scripts/start-production.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🚀 Démarrage de l'environnement de production Project Umbra"
+docker-compose -f docker-compose/production.yml up -d
+echo "✅ Environnement de production démarré"
+echo "🌐 API Gateway (production): http://localhost:8080"
+echo "📊 Monitoring (production): http://localhost:9090 | http://localhost:3001"

--- a/scripts/start-staging.sh
+++ b/scripts/start-staging.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🚀 Démarrage de l'environnement de staging Project Umbra"
+docker-compose -f docker-compose/staging.yml up -d
+echo "✅ Environnement de staging démarré"
+echo "🌐 API Gateway (staging): http://localhost:8080"
+echo "📊 Monitoring (staging): http://localhost:9090 | http://localhost:3001"

--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 echo "🛑 Arrêt de l'environnement de développement"
 docker-compose -f docker-compose/development.yml down
 echo "✅ Environnement arrêté"

--- a/scripts/stop-production.sh
+++ b/scripts/stop-production.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🛑 Arrêt de l'environnement de production"
+docker-compose -f docker-compose/production.yml down
+echo "✅ Environnement de production arrêté"

--- a/scripts/stop-staging.sh
+++ b/scripts/stop-staging.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🛑 Arrêt de l'environnement de staging"
+docker-compose -f docker-compose/staging.yml down
+echo "✅ Environnement de staging arrêté"


### PR DESCRIPTION
## Summary
- add dedicated staging docker-compose stack with helper scripts
- add production docker-compose stack with required environment configuration and management scripts
- document the local Git issues list and update the README with new workflows

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d97e7e6100833295ed369b4a510a84